### PR TITLE
feat: migrar banco de dados de SQLite para PostgreSQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "pg": "8.8.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,12 +8,16 @@ import { RecordModule } from './record/record.module'; // Certifique-se de impor
 @Module({
   imports: [
     TypeOrmModule.forRoot({
-      type: 'sqlite', // ou o tipo de banco de dados que você está usando
-      database: 'database.sqlite', // caminho do banco de dados
-      entities: [__dirname + '/**/*.entity{.ts,.js}'], // localização das entidades
-      synchronize: true, // deve ser usado apenas em desenvolvimento
+      type: 'postgres',
+      host: 'postgres',
+      port: 5432, 
+      username: 'user',
+      password: 'password',
+      database: 'cervejas',
+      entities: [__dirname + '/**/*.entity{.ts,.js}'],
+      synchronize: true,
     }),
-    RecordModule, // Adicione o RecordModule
+    RecordModule,
     UploadModule,
   ],
   controllers: [AppController],

--- a/src/record/record.controller.ts
+++ b/src/record/record.controller.ts
@@ -1,12 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { RecordService } from './record.service';
+import { Log } from './record.entity';
 
 @Controller('record')
 export class RecordController {
   constructor(private readonly logsService: RecordService) {}
 
   @Get()
-  findAll() {
-    // Lógica para retornar record
+  async findAll(): Promise<Log[]> {
+    return this.logsService.findAll();
   }
 }

--- a/src/record/record.entity.ts
+++ b/src/record/record.entity.ts
@@ -11,9 +11,10 @@ export class Log {
   @Column()
   brand: string;
 
-  @Column({ type: 'datetime' })
+  @Column({ type: 'timestamp' })
   created_at: Date;
 
   @Column()
   imagePath: string;
 }
+ 

--- a/src/record/record.service.ts
+++ b/src/record/record.service.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { Log } from './record.entity';
 
 @Injectable()
 export class RecordService {
-  // Lógica do serviço
+  constructor(@InjectRepository(Log) private logRepository: Repository<Log>) {}
+
+  async findAll(): Promise<Log[]> {
+    return this.logRepository.find();
+  }
 }


### PR DESCRIPTION
- Atualizada a configuração para usar PostgreSQL em vez de SQLite
- Refatorada a string de conexão com o banco de dados
- Ajustadas as configurações do Docker e do ambiente para suportar PostgreSQL
- Aplicadas as alterações necessárias no esquema para compatibilidade com PostgreSQL
